### PR TITLE
Add support for undefined variable in ng-csv directive

### DIFF
--- a/src/ng-csv/services/csv-service.js
+++ b/src/ng-csv/services/csv-service.js
@@ -58,12 +58,12 @@ angular.module('ngCsv.services').
           csvContent += headerString + EOL;
         }
 
-        var arrData;
+        var arrData = [];
 
         if (angular.isArray(responseData)) {
           arrData = responseData;
         }
-        else {
+        else if (angular.isFunction(responseData)) {
           arrData = responseData();
         }
 

--- a/test/unit/ngCsv/directives/ngCsv.js
+++ b/test/unit/ngCsv/directives/ngCsv.js
@@ -323,4 +323,24 @@ describe('ngCsv directive', function () {
     $timeout.flush();
     scope.$apply();
   });
+
+  it('Handles undefined variables without raising any exception', function (done) {
+    var element = $compile(
+      '<div ng-csv="undefinedVariable" field-separator="{{sep}}"' +
+      ' filename="custom.csv">' +
+      '</div>')($rootScope);
+    $rootScope.$digest();
+    $rootScope.sep = ';';
+    $rootScope.$digest();
+
+    var scope = element.isolateScope();
+    // Check that the compiled element has indeed undefined variable
+    expect(scope.$eval(scope.data)).toEqual(undefined);
+
+    scope.buildCSV(scope.data).then(function() {
+      expect(scope.csv).toBe('');
+      done();
+    });
+    scope.$apply();
+  });
 });


### PR DESCRIPTION
Currently `ng-csv="undefinedVariable"` will throw an exception because
of a bad function call to an undefined variable. This patch simply adds
a sanity check and returns an empty csv.
