### PR TITLE
Add decimal-separator option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ ngCsv attributes
   ```
 
 * field-separator: Defines the field separator character (default is ,)
+* decimal-separator: Defines the decimal separator character (default is .). If set to "locale", it uses the [language sensitive representation of the number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString).
 * text-delimiter: If provided, will use this characters to "escape" fields, otherwise will use double quotes as deafult
 * quote-strings: If provided, will force escaping of every string field.
 * lazy-load: If defined and set to true, ngCsv will generate the data string only on demand. See the lazy_load example for more details.

--- a/src/ng-csv/directives/ng-csv.js
+++ b/src/ng-csv/directives/ng-csv.js
@@ -13,6 +13,7 @@ angular.module('ngCsv.directives').
         filename: '@filename',
         header: '&csvHeader',
         txtDelim: '@textDelimiter',
+        decimalSep: '@decimalSeparator',
         quoteStrings: '@quoteStrings',
         fieldSep: '@fieldSeparator',
         lazyLoad: '@lazyLoad',
@@ -43,6 +44,7 @@ angular.module('ngCsv.directives').
           function getBuildCsvOptions() {
             var options = {
               txtDelim: $scope.txtDelim ? $scope.txtDelim : '"',
+              decimalSep: $scope.decimalSep ? $scope.decimalSep : '.',
               quoteStrings: $scope.quoteStrings,
               addByteOrderMarker: $scope.addByteOrderMarker
             };

--- a/src/ng-csv/services/csv-service.js
+++ b/src/ng-csv/services/csv-service.js
@@ -10,13 +10,25 @@ angular.module('ngCsv.services').
     /**
      * Stringify one field
      * @param data
-     * @param delimier
+     * @param options
      * @returns {*}
      */
-    this.stringifyField = function (data, delimier, quoteText) {
+    this.stringifyField = function (data, options) {
+      if (options.decimalSep === 'locale' && this.isFloat(data)) {
+        return data.toLocaleString();
+      }
+
+      if (options.decimalSep !== '.' && this.isFloat(data)) {
+        return data.toString().replace('.', options.decimalSep);
+      }
+
       if (typeof data === 'string') {
         data = data.replace(/"/g, '""'); // Escape double qoutes
-        if (quoteText || data.indexOf(',') > -1 || data.indexOf('\n') > -1 || data.indexOf('\r') > -1) data = delimier + data + delimier;
+
+        if (options.quoteStrings || data.indexOf(',') > -1 || data.indexOf('\n') > -1 || data.indexOf('\r') > -1) {
+            data = options.txtDelim + data + options.txtDelim;
+        }
+
         return data;
       }
 
@@ -25,6 +37,15 @@ angular.module('ngCsv.services').
       }
 
       return data;
+    };
+
+    /**
+     * Helper function to check if input is float
+     * @param input
+     * @returns {boolean}
+     */
+    this.isFloat = function (input) {
+      return +input === input && (!isFinite(input) || Boolean(input % 1));
     };
 
     /**
@@ -51,7 +72,7 @@ angular.module('ngCsv.services').
 
           encodingArray = [];
           angular.forEach(options.header, function (title, key) {
-            this.push(that.stringifyField(title, options.txtDelim, options.quoteStrings));
+            this.push(that.stringifyField(title, options));
           }, encodingArray);
 
           headerString = encodingArray.join(options.fieldSep ? options.fieldSep : ",");
@@ -73,7 +94,7 @@ angular.module('ngCsv.services').
           infoArray = [];
 
           angular.forEach(row, function (field, key) {
-            this.push(that.stringifyField(field, options.txtDelim, options.quoteStrings));
+            this.push(that.stringifyField(field, options));
           }, infoArray);
 
           dataString = infoArray.join(options.fieldSep ? options.fieldSep : ",");

--- a/test/unit/ngCsv/directives/ngCsv.js
+++ b/test/unit/ngCsv/directives/ngCsv.js
@@ -21,6 +21,7 @@ describe('ngCsv directive', function () {
     $timeout = _$timeout_;
     $rootScope.test = [[1, 2, 3], [4, 5, 6]];
     $rootScope.testObj = [{a: 1, b: 2, c: 3}, {a: 4, b: 5, c: 6}];
+    $rootScope.testDecimal = [[13.37]];
 
     var _deferred = $q.defer();
     _deferred.resolve([[1, 2, 3], [4, 5, 6]]);
@@ -403,4 +404,49 @@ describe('ngCsv directive', function () {
 
   });
 
+  it('should convert decimal values to localeString if decimal-separator="locale"', function(done) {
+    $rootScope.decSep = 'locale';
+
+    var element = $compile(
+      '<div ng-csv="testDecimal" decimal-separator="{{decSep}}"' +
+      ' filename="custom.csv">' +
+      '</div>')($rootScope);
+
+      $rootScope.$digest();
+
+      var scope = element.isolateScope();
+
+      expect(scope.decimalSep).toBe($rootScope.decSep);
+
+      scope.buildCSV(scope.data).then(function() {
+        var locale = $rootScope.testDecimal[0][0].toLocaleString();
+
+        expect(scope.csv).toBe(locale + '\r\n');
+        done();
+      });
+
+    scope.$apply();
+  });
+
+  it('should convert decimal values using the decimal-separator option', function(done) {
+    $rootScope.decSep = ',';
+
+    var element = $compile(
+      '<div ng-csv="testDecimal" decimal-separator="{{decSep}}"' +
+      ' filename="custom.csv">' +
+      '</div>')($rootScope);
+
+      $rootScope.$digest();
+
+      var scope = element.isolateScope();
+
+      expect(scope.decimalSep).toBe($rootScope.decSep);
+
+      scope.buildCSV(scope.data).then(function() {
+        expect(scope.csv).toBe('13,37\r\n');
+        done();
+      });
+
+    scope.$apply();
+  });
 });

--- a/test/unit/ngCsv/services/csv-service.js
+++ b/test/unit/ngCsv/services/csv-service.js
@@ -1,0 +1,64 @@
+'use strict';
+/* jshint indent: 2*/
+// Set the jasmine fixture path
+// jasmine.getFixtures().fixturesPath = 'base/';
+
+describe('ngCsv service', function () {
+  var CSV;
+
+  beforeEach(function() {
+    module('ngCsv.services');
+
+    inject(function (_CSV_) {
+      CSV = _CSV_;
+    });
+  });
+
+  describe('isFloat', function () {
+    it('should return true if input is float', function () {
+      var testCases = [
+      13.37,
+      0.01,
+      1.01,
+      -13.37
+      ];
+
+      angular.forEach(testCases, function (testCase) {
+        expect(CSV.isFloat(testCase)).toBeTruthy();
+      });
+    });
+
+    it('should return false if input is not float (but an integer)', function() {
+      var testCases = [
+      1.00,
+      0.00,
+      -1.00,
+      1,
+      0,
+      -1
+      ];
+
+      angular.forEach(testCases, function (testCase) {
+        expect(CSV.isFloat(testCase)).toBeFalsy();
+      });
+    });
+
+    it('should return false if input is not an integer', function() {
+      var testCases = [
+      'abc',
+      '13.37',
+      null,
+      {},
+      function () {
+      },
+      [],
+      false,
+      true
+      ];
+
+      angular.forEach(testCases, function (testCase) {
+        expect(CSV.isFloat(testCase)).toBeFalsy();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This is useful if the target operation system uses different character for decimal separator.

> Microsoft Excel will open .csv files, but depending on the system's regional settings, it may expect a semicolon as a separator instead of a comma, since in some languages the comma is used as the decimal separator.