### PR TITLE
tab separated value as field separator

### DIFF
--- a/src/ng-csv/directives/ng-csv.js
+++ b/src/ng-csv/directives/ng-csv.js
@@ -50,6 +50,9 @@ angular.module('ngCsv.directives').
             };
             if (angular.isDefined($attrs.csvHeader)) options.header = $scope.$eval($scope.header);
             options.fieldSep = $scope.fieldSep ? $scope.fieldSep : ",";
+            
+            // can handle tab separated value
+            options.fieldSep = (options.fieldSep === "\\t") ? "\t" : options.fieldSep;
 
             return options;
           }


### PR DESCRIPTION
If you only pass in <a ng-csv="getData()" field-separator="\t">Get TSV</a>, angular escapes the "\t" and doesnt give you the tab character. This correctly lets you use \t as a valid separator.