### PR TITLE
Angular.copy fix for firefox unresponsive script warning

### DIFF
--- a/src/ng-csv/services/csv-service.js
+++ b/src/ng-csv/services/csv-service.js
@@ -73,7 +73,7 @@ angular.module('ngCsv.services').
       var csvContent = "";
 
       var dataPromise = $q.when(data).then(function (responseData) {
-        responseData = angular.copy(responseData);
+        //responseData = angular.copy(responseData);//moved to row creation
         // Check if there's a provided header array
         if (angular.isDefined(options.header) && options.header) {
           var encodingArray, headerString;
@@ -96,7 +96,8 @@ angular.module('ngCsv.services').
           arrData = responseData();
         }
 
-        angular.forEach(arrData, function (row, index) {
+        angular.forEach(arrData, function (oldRow, index) {
+          var row = angular.copy(arrData[index]);
           var dataString, infoArray;
 
           infoArray = [];


### PR DESCRIPTION
On large data sets doing an angular copy of the full data results in unresponsive script warnings in firefox. This change cut me from ~20sec to less than 1.