### PR TITLE
Fixes downloads on ionic (non-native).

### DIFF
--- a/src/ng-csv/directives/ng-csv.js
+++ b/src/ng-csv/directives/ng-csv.js
@@ -91,12 +91,13 @@ angular.module('ngCsv.directives').
             navigator.msSaveBlob(blob, scope.getFilename());
           } else {
 
-            var downloadLink = angular.element('<a></a>');
+            var downloadContainer = angular.element('<div data-tap-disabled="true"><a></a></div>');
+            var downloadLink = angular.element(downloadContainer.children()[0]);
             downloadLink.attr('href', window.URL.createObjectURL(blob));
             downloadLink.attr('download', scope.getFilename());
             downloadLink.attr('target', '_blank');
 
-            $document.find('body').append(downloadLink);
+            $document.find('body').append(downloadContainer);
             $timeout(function () {
               downloadLink[0].click();
               downloadLink.remove();


### PR DESCRIPTION
Hey there,

This fixes up exports on ionic (for sure in non-native apps).  It adds a wrapping tag to disable ionic's tap-handling which should be backwards-compatible with existing pages.

Fixes #103 .

Let me know if you need anything else, and thanks for the great plugin!