### PR TITLE
Added label attribute to define whether or not using keys as column value

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ ngCsv attributes
 * lazy-load: If defined and set to true, ngCsv will generate the data string only on demand. See the lazy_load example for more details.
 * add-bom: Add the Byte Order Mark, use this option if you are getting an unexpected char when opening the file on any windows App.
 * charset: Defines the charset of the downloadable Csv file. Default is "utf-8".
-
+* csv-label: Defines whether or not using keys as csv column value (default is false).
 ## Examples
 You can check out this live example here: https://asafdav.github.io/ng-csv/example/
 

--- a/src/ng-csv/directives/ng-csv.js
+++ b/src/ng-csv/directives/ng-csv.js
@@ -20,7 +20,8 @@ angular.module('ngCsv.directives').
         lazyLoad: '@lazyLoad',
         addByteOrderMarker: "@addBom",
         ngClick: '&',
-        charset: '@charset'
+        charset: '@charset',
+        label: '&csvLabel'
       },
       controller: [
         '$scope',
@@ -51,6 +52,7 @@ angular.module('ngCsv.directives').
             };
             if (angular.isDefined($attrs.csvHeader)) options.header = $scope.$eval($scope.header);
             if (angular.isDefined($attrs.csvColumnOrder)) options.columnOrder = $scope.$eval($scope.columnOrder);
+            if (angular.isDefined($attrs.csvLabel)) options.label = $scope.$eval($scope.label);
 
             options.fieldSep = $scope.fieldSep ? $scope.fieldSep : ",";
 

--- a/src/ng-csv/services/csv-service.js
+++ b/src/ng-csv/services/csv-service.js
@@ -87,6 +87,18 @@ angular.module('ngCsv.services').
           csvContent += headerString + EOL;
         }
 
+        // Check if using keys as labels
+        if (angular.isDefined(options.label) && options.label && typeof options.label === 'boolean') {
+            var encodingArray, labelString;
+            
+            encodingArray = [];
+            angular.forEach(arrData[0], function(value, label) {
+                this.push(that.stringifyField(label, options));
+            }, encodingArray);
+            labelString = encodingArray.join(options.fieldSep ? options.fieldSep : ",");
+            csvContent += labelString + EOL;
+        }
+
         var arrData = [];
 
         if (angular.isArray(responseData)) {

--- a/src/ng-csv/services/csv-service.js
+++ b/src/ng-csv/services/csv-service.js
@@ -87,6 +87,15 @@ angular.module('ngCsv.services').
           csvContent += headerString + EOL;
         }
 
+        var arrData = [];
+
+        if (angular.isArray(responseData)) {
+          arrData = responseData;
+        }
+        else if (angular.isFunction(responseData)) {
+          arrData = responseData();
+        }
+
         // Check if using keys as labels
         if (angular.isDefined(options.label) && options.label && typeof options.label === 'boolean') {
             var encodingArray, labelString;
@@ -97,15 +106,6 @@ angular.module('ngCsv.services').
             }, encodingArray);
             labelString = encodingArray.join(options.fieldSep ? options.fieldSep : ",");
             csvContent += labelString + EOL;
-        }
-
-        var arrData = [];
-
-        if (angular.isArray(responseData)) {
-          arrData = responseData;
-        }
-        else if (angular.isFunction(responseData)) {
-          arrData = responseData();
         }
 
         angular.forEach(arrData, function (oldRow, index) {

--- a/test/unit/ngCsv/directives/ngCsv.js
+++ b/test/unit/ngCsv/directives/ngCsv.js
@@ -129,6 +129,27 @@ describe('ngCsv directive', function () {
     scope.$apply();
   });
 
+  it('Creates a header row using keys if csv-label sets to true', function (done) {
+    // Compile a piece of HTML containing the directive
+    $rootScope.testDelim = [ {a:1, b:2, c:3}, {a:4, b:5, c:6} ];
+    var element = $compile(
+      '<div ng-csv="testDelim" csv-label="true" filename="custom.csv"></div>')($rootScope);
+    
+    $rootScope.$digest();
+
+    var scope = element.isolateScope();
+
+    // Check that the compiled element contains the templated content
+    expect(scope.$eval(scope.data)).toEqual($rootScope.testDelim);
+    
+
+    scope.buildCSV(scope.data).then(function() {
+      expect(scope.csv).toBe('a,b,c\r\n1,2,3\r\n4,5,6\r\n');
+      done();
+    });
+    scope.$apply();
+  });
+
   it('Accepts optional csv-column-order attribute (input array)', function (done) {
     $rootScope.testDelim = [ {a:1, b:2, c:3}, {a:4, b:5, c:6} ];
     $rootScope.order = [ 'b', 'a', 'c' ];


### PR DESCRIPTION
Using all the keys in first object of array to create the header for CSV file when csv-label set it to true.
It only accepts Boolean value.
`ng-csv="dataArray" csv-label="true"`
Input data:
`$scopedataArray = [
    {
        "Vehicle": "BMW",
        "Date": "30, Jul 2013 09:24 AM",
        "Location": "Hauz Khas, Enclave, New Delhi, Delhi, India",
        "Speed": 42
    },
    {
        "Vehicle": "Honda CBR",
        "Date": "30, Jul 2013 12:00 AM",
        "Location": "Military Road,  West Bengal 734013,  India",
        "Speed": 0
    }
];`

Output file:
![ng-csvheader](https://cloud.githubusercontent.com/assets/6677092/10257399/23e54e1a-6925-11e5-9df9-d9af5ac61c24.png)

