### PR TITLE
feat(skip-empty) added new option to skip downloading empty CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ ngCsv attributes
 * decimal-separator: Defines the decimal separator character (default is .). If set to "locale", it uses the [language sensitive representation of the number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString).
 * text-delimiter: If provided, will use this characters to "escape" fields, otherwise will use double quotes as deafult
 * quote-strings: If provided, will force escaping of every string field.
+* skip-empty: If provided, will not trigger the download of empty data (default is false).
 * lazy-load: If defined and set to true, ngCsv will generate the data string only on demand. See the lazy_load example for more details.
 * add-bom: Add the Byte Order Mark, use this option if you are getting an unexpected char when opening the file on any windows App.
 * charset: Defines the charset of the downloadable Csv file. Default is "utf-8".

--- a/src/ng-csv/directives/ng-csv.js
+++ b/src/ng-csv/directives/ng-csv.js
@@ -21,7 +21,8 @@ angular.module('ngCsv.directives').
         addByteOrderMarker: "@addBom",
         ngClick: '&',
         charset: '@charset',
-        label: '&csvLabel'
+        label: '&csvLabel',
+        skipEmpty: '@skipEmpty'
       },
       controller: [
         '$scope',
@@ -84,6 +85,10 @@ angular.module('ngCsv.directives').
       ],
       link: function (scope, element, attrs) {
         function doClick() {
+
+          // drop out for empty data
+          if (!scope.csv.trim() && scope.skipEmpty === "true") {return;}
+
           var charset = scope.charset || "utf-8";
           var blob = new Blob([scope.csv], {
             type: "text/csv;charset="+ charset + ";"


### PR DESCRIPTION

Found an issue when using ng-csv to export a file in conjunction with some validation. I was finding that the ng-csv would still trigger the download, even when the validation rules were failing (meaning underlying data was empty)

The behaviour I was seeking was to prevent the download in this case.

This PR provides the behaviour by adding a new attribute "skip-data" (default false). When the directive is set, the CSV file will only be delivered to the browser when there is actual content. 