### PR TITLE
Adds back the 'tel:' protocol (e.g. phone links) to $compileProviders link whitelist 

### DIFF
--- a/src/ng-csv/ng-csv.js
+++ b/src/ng-csv/ng-csv.js
@@ -9,9 +9,9 @@ angular.module('ngCsv.config', []).
   }).
   config(['$compileProvider', function($compileProvider){
     if (angular.isDefined($compileProvider.urlSanitizationWhitelist)) {
-      $compileProvider.urlSanitizationWhitelist(/^\s*(https?|ftp|mailto|file|data):/);
+      $compileProvider.urlSanitizationWhitelist(/^\s*(https?|ftp|mailto|tel|file|data):/);
     } else {
-      $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|ftp|mailto|file|data):/);
+      $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|ftp|mailto|tel|file|data):/);
     }
   }]);
 


### PR DESCRIPTION
Angular `$compileProviders`'s default link whitelist (e.g. list of safe links) is defined as `/^\s*(https?|ftp|mailto|tel|file):/`. But [this line here](https://github.com/asafdav/ng-csv/blob/master/src/ng-csv/ng-csv.js#L12) accidently removes `tel:` links from the whitelist.

This pull request restores angular's default behaviour.