### PR TITLE
fix escaping if quote is present in field

### DIFF
--- a/src/ng-csv/services/csv-service.js
+++ b/src/ng-csv/services/csv-service.js
@@ -33,7 +33,7 @@ angular.module('ngCsv.services').
       if (typeof data === 'string') {
         data = data.replace(/"/g, '""'); // Escape double qoutes
 
-        if (options.quoteStrings || data.indexOf(',') > -1 || data.indexOf('\n') > -1 || data.indexOf('\r') > -1) {
+        if (options.quoteStrings || data.indexOf(',') > -1 || data.indexOf('\n') > -1 || data.indexOf('\r') > -1 || data.indexOf('"') > -1) {
             data = options.txtDelim + data + options.txtDelim;
         }
 


### PR DESCRIPTION
Escape the field with double quotes if it contains a double quote in the value.

This is specified in the [RFC](https://www.ietf.org/rfc/rfc4180.txt) as follows:

>  6 .  Fields containing line breaks (CRLF), **double quotes**, and commas
>         should be enclosed in double-quotes. 
