### PR TITLE
force quote strings with spaces

### DIFF
--- a/src/ng-csv/services/csv-service.js
+++ b/src/ng-csv/services/csv-service.js
@@ -33,7 +33,7 @@ angular.module('ngCsv.services').
       if (typeof data === 'string') {
         data = data.replace(/"/g, '""'); // Escape double qoutes
 
-        if (options.quoteStrings || data.indexOf(',') > -1 || data.indexOf('\n') > -1 || data.indexOf('\r') > -1) {
+        if (options.quoteStrings || data.indexOf(' ') > -1 || data.indexOf(',') > -1 || data.indexOf('\n') > -1 || data.indexOf('\r') > -1) {
             data = options.txtDelim + data + options.txtDelim;
         }
 


### PR DESCRIPTION
Hi, 

libreoffice version 4 (yeah, it's ancient ...) does not import fields with embedded whitespaces correctly. For instance a field with contents  `"hi" there` will be exported to `;""hi"" there;` , but libreoffice does not honour the seperator tripping over later fields.

Even Excel 2010 does not import  `;""hi"" there;` correctly: It displays the double quote chars, not a single one.

With the supplied patch, the field will be exported as `;"""hi"" there";` which leads to correct exports in both libreoffice 4 and excel 2010.
