### PR TITLE
Enhancement: Updated to work for IE9 and Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,5 @@ Supported Browsers
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/asafdav/ng-csv/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 
 ## Running testcases
+
+karma start

--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ Supported Browsers
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/asafdav/ng-csv/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 
+## Running testcases


### PR DESCRIPTION
File downloaded with .txt extension in IE9 with saveas window, So here we can change extension to .csv while downloading. Some times IE9 failing to download file with '.csv' extension, in that scenario downloading with '.txt' extension works fine.
In Safari file downloaded with file name 'Unknown' with no extension, didn't find any possibility to downloaded file as given name.
For others browsers same code is followed.
Still need to check for fixing the known bugs.
Updated read me,