### PR TITLE
Allow any 1.* version for angular

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,11 +3,11 @@
   "version": "0.3.6",
   "main": "build/ng-csv.min.js",
   "dependencies": {
-    "angular": "~1",
-    "angular-sanitize": "~1"
+    "angular": "~1.0",
+    "angular-sanitize": "~1.0"
   },
   "devDependencies": {
-    "angular-mocks": "~1",
-    "angular-scenario": "~1"
+    "angular-mocks": "~1.0",
+    "angular-scenario": "~1.0"
   }
 }


### PR DESCRIPTION
You shouldn't force users to pull only latest major version of angular and dep. `~1` prevent the use of angular 1.5.*.

Change to `~1.0`