### PR TITLE
jQuery 3+ deprecated `.bind`. Using `on` to attach an event handler i…

### DIFF
--- a/src/ng-csv/directives/ng-csv.js
+++ b/src/ng-csv/directives/ng-csv.js
@@ -113,7 +113,7 @@ angular.module('ngCsv.directives').
           }
         }
 
-        element.bind('click', function (e) {
+        element[element.on ? 'on' : 'bind']('click', function (e) {
           scope.buildCSV().then(function (csv) {
             doClick();
           });


### PR DESCRIPTION
instead of `.bind`.

Fix taken from ui-router:
https://github.com/angular-ui/ui-router/commit/a8aa40ab7c1433904b1f53f506d42d0faca14c3b